### PR TITLE
Improve error handling

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -113,6 +113,8 @@
     });
     $.get('/signalk/v1/api/vessels/self/environment/depth/belowTransducer/value', (depth) => {
       $('#depthValue').html(depth);
+    }).fail(() => {
+      $('#depthValue').html("~");
     });
     $.get('/signalk/v1/api/vessels', (vessels) => {
       let detectedTargets = [];
@@ -129,7 +131,7 @@
 	if (distance <= maxRadius * 5) {
 	  detectedTargets.push(vessel.mmsi);
 	  distance = Math.round(distance*10)/10;
-	  let name = vessel.name.split(' ')
+	  let name = vessel.name?.split(' ')
 			   .map(w => w[0].toUpperCase() + w.substring(1).toLowerCase())
    			   .join(' ');
 	  if (vessel.mmsi in target) {

--- a/public/index.html
+++ b/public/index.html
@@ -157,7 +157,7 @@
       data = data.navigation;
       latitude = data.position.value.latitude;
       longitude = data.position.value.longitude;
-      let heading = data.headingTrue.value;
+      let heading = data.headingTrue?.value;
       if (heading) {
         heading = heading *  57.295779513; // Convert to degrees
       } else {
@@ -187,7 +187,7 @@
   	  $.get('/signalk/v1/api/vessels/self/navigation', (data) => {
             latitude = data.position.value.latitude;
       	    longitude = data.position.value.longitude;
-      	    let heading = data.headingTrue.value;
+      	    let heading = data.headingTrue?.value;
       	    if (heading) {
               heading = heading *  57.295779513; // Convert to degrees
       	    } else {


### PR DESCRIPTION
If self.navigation.headingTrue does not exist the the webapp crashes and wont start. It's possible for people to not have this if the chart plotter doesn't have a magneticCompass attached.,
Capture this using nullish (set to 0 check is already present)

If depth.belowTransducer isn't available, set value to ~ instead of the default zero / last value to alert to bad data

During startup/handshaking it's possible to have AIS information about a vessel, but not it's name, nullish to end up with "undefined" vessel name and remove errors in console